### PR TITLE
reconfigure leaderboard to store bots

### DIFF
--- a/src/components/Dropdown/Dropdown.module.css
+++ b/src/components/Dropdown/Dropdown.module.css
@@ -10,10 +10,6 @@
 	line-height: 16px;
 	height: 25px;
 	min-width: 60px;
-<<<<<<< HEAD
-	padding: 0 8px;
-=======
->>>>>>> 6ed13e1 (Revert "Revert "added dropdown arrow img to public folder || Created Input, Slide, & …"")
 }
 
 /* Image in button */

--- a/src/components/LeaderBoard/LeaderBoard/LeaderBoard.jsx
+++ b/src/components/LeaderBoard/LeaderBoard/LeaderBoard.jsx
@@ -1,26 +1,44 @@
-import React, { useEffect, useContext }  from 'react';
+import React, { useState, useEffect, useContext }  from 'react';
 import styles from './LeaderBoard.module.css'
 import BotStatistics from '../BotStatistics/BotStatistics';
 import { GameContext } from '../../../context/GameContext/GameContext';
 
-const defaultBots = [{
-    name: 'Bot1', 
-    wins: 11, 
-    losses: 0
-    }, {
-    name: 'Bot2', 
-    wins: 17, 
-    losses: 5
-    }, {
-    name: 'Bot3', 
-    wins: 1, 
-    losses: 10
-    }]
-
 const LeaderBoard = () => {
-  const { bots, addBot } = useContext(GameContext);
+  const { bots } = useContext(GameContext);
+  const [uniqueBots, setUniqueBots] = useState([])
 
-console.log(bots)
+  const storeBot = () => {
+    bots.forEach(bot => {
+      //for the first round when unique bots array is still empty, we copy all the bots
+      if (uniqueBots.length === 0) {
+        setUniqueBots(prevUniqueBots => [...prevUniqueBots, bot]);
+      } else {
+      // every other round we check for the matching names/indexes in bots array
+        const botIndex = uniqueBots.findIndex(el => el.name === bot.name);
+        if (botIndex !== -1) {
+          console.log(`bot already exists at index ${botIndex}`);
+          const updatedBot = {
+            name: bot.name,
+            wins: bot.wins+uniqueBots[botIndex].wins,
+            losses: bot.losses+uniqueBots[botIndex].losses,
+          };
+          //only update the bot that needs tally increment
+          setUniqueBots(prevUniqueBots => [
+            ...prevUniqueBots.slice(0, botIndex),
+            updatedBot,
+            ...prevUniqueBots.slice(botIndex + 1),
+          ]);
+        } else {
+          //if no matching names, we add Bot straight to a UniqueBots array
+          setUniqueBots(prevUniqueBots => [...prevUniqueBots, bot]);
+        }
+      }
+    });
+  };
+
+  useEffect(() => {
+    storeBot()
+  }, [bots])
 
   return (
     <div className={styles.wrapper}>
@@ -31,7 +49,7 @@ console.log(bots)
                 <h3>Wins</h3>
                 <h3>Losses</h3>
             </div>
-            <BotStatistics bots={ bots }/>
+            <BotStatistics bots={uniqueBots}/>
         </div>
     </div>
   )

--- a/src/components/LeaderBoard/LeaderBoard/LeaderBoard.test.jsx
+++ b/src/components/LeaderBoard/LeaderBoard/LeaderBoard.test.jsx
@@ -1,28 +1,21 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
 import LeaderBoard from './LeaderBoard';
 
 describe('LeaderBoard', () => {
-  const mockBots = [
-    {
-      name: 'Bot1',
-      wins: 11,
-      losses: 0,
-    },
-    {
-      name: 'Bot2',
-      wins: 17,
-      losses: 5,
-    },
-    {
-      name: 'Bot3',
-      wins: 1,
-      losses: 10,
-    },
-  ];
+  // Mock the GameContext
+jest.mock('../../../context/GameContext/GameContext', () => ({
+  GameContext: {
+    bots: [
+      { name: 'Bot1', wins: 1, losses: 0 },
+      { name: 'Bot2', wins: 0, losses: 1 },
+    ],
+  },
+}));
+
 
   test('renders the LeaderBoard component with correct headings', () => {
-    render(<LeaderBoard bots={mockBots} />);
+    render(<LeaderBoard />);
 
     // Assert that the "Leaders" heading is rendered
     const leadersHeading = screen.getByRole('heading', { level: 2, name: /leaders/i });
@@ -39,7 +32,7 @@ describe('LeaderBoard', () => {
   });
 
   test('renders the BotStatistics component with the correct number of bots', () => {
-    render(<LeaderBoard bots={mockBots} />);
+    render(<LeaderBoard />);
 
     // Assert that the BotStatistics component is rendered
     const botStatisticsComponent = screen.getByTestId('bot-statistics');
@@ -47,6 +40,43 @@ describe('LeaderBoard', () => {
 
     // Assert that the correct number of bots are rendered within the BotStatistics component
     const botItems = screen.getAllByTestId('bot-item');
-    expect(botItems.length).toBe(mockBots.length);
+    expect(botItems.length).toBe(bots.length);
+  });
+
+  test('adds bots to uniqueBots array and updates bot\'s wins/losses', () => {
+    render(<LeaderBoard />);
+  
+    // Mock the useState hook for bots and setBots
+    const setBots = jest.fn();
+    jest.mock('react', () => ({
+      ...jest.requireActual('react'),
+      useState: initialBots => [initialBots, setBots],
+    }));
+  
+    // Set the initial state for bots
+    act(() => {
+      setBots([
+        { name: 'Bot1', wins: 1, losses: 0 },
+        { name: 'Bot2', wins: 0, losses: 1 },
+      ]);
+    });
+  
+    expect(bots).toEqual([
+      { name: 'Bot1', wins: 1, losses: 0 },
+      { name: 'Bot2', wins: 0, losses: 1 },
+    ]);
+  
+    // Add another bot and check the updated state of bots
+    act(() => {
+      setBots(prevBots => [
+        ...prevBots,
+        { name: 'Bot2', wins: 2, losses: 1 },
+      ]);
+    });
+  
+    expect(bots).toEqual([
+      { name: 'Bot1', wins: 1, losses: 0 },
+      { name: 'Bot2', wins: 2, losses: 2 },
+    ]);
   });
 });


### PR DESCRIPTION
Leaderboard - reconfigure leaderboard so it stores bot objects, display wins/losses,  check for matching names  and if so, add increment to win and loss totals.
